### PR TITLE
Implement traits for Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ default = ["std", "derive"]
 std = []
 array_impl = []
 tuple_impl = ["paste"]
+vec_impl = []
 derive = []
 
 [dependencies]

--- a/src/abs_diff_eq.rs
+++ b/src/abs_diff_eq.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "vec_impl")]
+use alloc::vec::Vec;
 use core::cell;
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
@@ -297,6 +299,27 @@ mod abs_diff_eq_tuple_impls {
     impl_abs_diff_eq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     impl_abs_diff_eq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     impl_abs_diff_eq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+}
+
+#[cfg(feature = "vec_impl")]
+#[cfg_attr(docsrs, doc(cfg(feature = "vec_impl")))]
+impl<A, B> AbsDiffEq<Vec<B>> for Vec<A>
+where
+    A: AbsDiffEq<B>,
+    A::Epsilon: Clone,
+{
+    type Epsilon = A::Epsilon;
+
+    #[inline]
+    fn default_epsilon() -> A::Epsilon {
+        A::default_epsilon()
+    }
+
+    #[inline]
+    fn abs_diff_eq(&self, other: &Vec<B>, epsilon: A::Epsilon) -> bool {
+        self.len() == other.len()
+            && Iterator::zip(self.iter(), other).all(|(x, y)| A::abs_diff_eq(x, y, epsilon.clone()))
+    }
 }
 
 #[cfg(feature = "num-complex")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,9 @@ extern crate num_traits;
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered-float")))]
 extern crate ordered_float;
 
+#[cfg(feature = "vec_impl")]
+extern crate alloc;
+
 mod abs_diff_eq;
 mod relative_eq;
 mod ulps_eq;

--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -1,4 +1,6 @@
 use crate::AbsDiffEq;
+#[cfg(feature = "vec_impl")]
+use alloc::vec::Vec;
 use core::{cell, f32, f64};
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
@@ -247,6 +249,26 @@ where
 
     #[inline]
     fn relative_eq(&self, other: &[B; N], epsilon: A::Epsilon, max_relative: A::Epsilon) -> bool {
+        self.len() == other.len()
+            && Iterator::zip(self.iter(), other)
+                .all(|(x, y)| A::relative_eq(x, y, epsilon.clone(), max_relative.clone()))
+    }
+}
+
+#[cfg(feature = "vec_impl")]
+#[cfg_attr(docsrs, doc(cfg(feature = "vec_impl")))]
+impl<A, B> RelativeEq<Vec<B>> for Vec<A>
+where
+    A: RelativeEq<B>,
+    A::Epsilon: Clone,
+{
+    #[inline]
+    fn default_max_relative() -> A::Epsilon {
+        A::default_max_relative()
+    }
+
+    #[inline]
+    fn relative_eq(&self, other: &Vec<B>, epsilon: A::Epsilon, max_relative: A::Epsilon) -> bool {
         self.len() == other.len()
             && Iterator::zip(self.iter(), other)
                 .all(|(x, y)| A::relative_eq(x, y, epsilon.clone(), max_relative.clone()))

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "vec_impl")]
+use alloc::vec::Vec;
 use core::cell;
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
@@ -195,6 +197,26 @@ where
 
     #[inline]
     fn ulps_eq(&self, other: &[B; N], epsilon: A::Epsilon, max_ulps: u32) -> bool {
+        self.len() == other.len()
+            && Iterator::zip(self.iter(), other)
+                .all(|(x, y)| A::ulps_eq(x, y, epsilon.clone(), max_ulps.clone()))
+    }
+}
+
+#[cfg(feature = "vec_impl")]
+#[cfg_attr(docsrs, doc(cfg(feature = "vec_impl")))]
+impl<A, B> UlpsEq<Vec<B>> for Vec<A>
+where
+    A: UlpsEq<B>,
+    A::Epsilon: Clone,
+{
+    #[inline]
+    fn default_max_ulps() -> u32 {
+        A::default_max_ulps()
+    }
+
+    #[inline]
+    fn ulps_eq(&self, other: &Vec<B>, epsilon: A::Epsilon, max_ulps: u32) -> bool {
         self.len() == other.len()
             && Iterator::zip(self.iter(), other)
                 .all(|(x, y)| A::ulps_eq(x, y, epsilon.clone(), max_ulps.clone()))

--- a/tests/abs_diff_eq.rs
+++ b/tests/abs_diff_eq.rs
@@ -491,6 +491,32 @@ mod test_array {
     }
 }
 
+#[cfg(feature = "vec_impl")]
+mod test_vec {
+    extern crate alloc;
+    use alloc::vec::Vec;
+
+    mod test_f32 {
+        use super::*;
+
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(Vec::from([1.0f32, 2.0f32]), Vec::from([1.0f32, 2.0f32]));
+            assert_abs_diff_ne!(Vec::from([1.0f32, 2.0f32]), Vec::from([2.0f32, 1.0f32]));
+        }
+    }
+
+    mod test_f64 {
+        use super::*;
+
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(Vec::from([1.0f64, 2.0f64]), Vec::from([1.0f64, 2.0f64]));
+            assert_abs_diff_ne!(Vec::from([1.0f64, 2.0f64]), Vec::from([2.0f64, 1.0f64]));
+        }
+    }
+}
+
 #[cfg(feature = "tuple_impl")]
 mod test_tuple{
     use approxim::AbsDiffEq;

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -497,6 +497,32 @@ mod test_array {
     }
 }
 
+#[cfg(feature = "vec_impl")]
+mod test_vec {
+    extern crate alloc;
+    use alloc::vec::Vec;
+
+    mod test_f32 {
+        use super::*;
+
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(Vec::from([1.0f32, 2.0f32]), Vec::from([1.0f32, 2.0f32]));
+            assert_relative_ne!(Vec::from([1.0f32, 2.0f32]), Vec::from([2.0f32, 1.0f32]));
+        }
+    }
+
+    mod test_f64 {
+        use super::*;
+
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(Vec::from([1.0f64, 2.0f64]), Vec::from([1.0f64, 2.0f64]));
+            assert_relative_ne!(Vec::from([1.0f64, 2.0f64]), Vec::from([2.0f64, 1.0f64]));
+        }
+    }
+}
+
 #[cfg(feature = "tuple_impl")]
 mod test_tuple{
     use approxim::RelativeEq;

--- a/tests/ulps_eq.rs
+++ b/tests/ulps_eq.rs
@@ -460,6 +460,32 @@ mod test_array {
     }
 }
 
+#[cfg(feature = "vec_impl")]
+mod test_vec {
+    extern crate alloc;
+    use alloc::vec::Vec;
+
+    mod test_f32 {
+        use super::*;
+
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(Vec::from([1.0f32, 2.0f32]), Vec::from([1.0f32, 2.0f32]));
+            assert_ulps_ne!(Vec::from([1.0f32, 2.0f32]), Vec::from([2.0f32, 1.0f32]));
+        }
+    }
+
+    mod test_f64 {
+        use super::*;
+
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(Vec::from([1.0f64, 2.0f64]), Vec::from([1.0f64, 2.0f64]));
+            assert_ulps_ne!(Vec::from([1.0f64, 2.0f64]), Vec::from([2.0f64, 1.0f64]));
+        }
+    }
+}
+
 #[cfg(feature = "tuple_impl")]
 mod test_tuple{
     use approxim::UlpsEq;


### PR DESCRIPTION
This PR implements `AbsDiffEq`, `RelativeEq` and `UlpsEq` for `Vec`.

I can see that brendanzab/approx#69 exists, but it does not seem to have been transferred to approxim. Was there a reason after all to not implement these traits for `Vec`?