### PR TITLE
Implement traits for IndexMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ std = []
 array_impl = []
 tuple_impl = ["paste"]
 vec_impl = []
+indexmap_impl = ["dep:indexmap"]
 derive = []
 
 [dependencies]
@@ -39,3 +40,4 @@ num-complex = { version = "0.4.6", optional = true }
 ordered-float = { version = "5.0", optional = true }
 approx-derive = { version = "0.2.7", features = ["infer_name"] }
 paste = { version = "1.0.15", optional = true }
+indexmap = { version = "2.12.1", optional = true, default-features = false }

--- a/src/abs_diff_eq.rs
+++ b/src/abs_diff_eq.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "vec_impl")]
 use alloc::vec::Vec;
 use core::cell;
+#[cfg(feature = "indexmap_impl")]
+use core::hash::{BuildHasher, Hash};
+#[cfg(feature = "indexmap_impl")]
+use indexmap::IndexMap;
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
 #[cfg(feature = "ordered-float")]
@@ -403,5 +407,33 @@ impl<T: AbsDiffEq + Float + ordered_float::FloatCore> AbsDiffEq<T> for OrderedFl
     #[inline]
     fn abs_diff_eq(&self, other: &T, epsilon: Self::Epsilon) -> bool {
         T::abs_diff_eq(&self.into_inner(), other, epsilon)
+    }
+}
+
+#[cfg(feature = "indexmap_impl")]
+#[cfg_attr(docsrs, doc(cfg(feature = "indexmap_impl")))]
+impl<K, V1, V2, S1, S2> AbsDiffEq<IndexMap<K, V2, S2>> for IndexMap<K, V1, S1>
+where
+    K: Hash + Eq,
+    V1: AbsDiffEq<V2>,
+    V1::Epsilon: Clone,
+    S1: BuildHasher,
+    S2: BuildHasher,
+{
+    type Epsilon = V1::Epsilon;
+
+    #[inline]
+    fn default_epsilon() -> V1::Epsilon {
+        V1::default_epsilon()
+    }
+
+    #[inline]
+    fn abs_diff_eq(&self, other: &IndexMap<K, V2, S2>, epsilon: Self::Epsilon) -> bool {
+        self.len() == other.len()
+            && self.iter().all(|(key, value)| {
+                other
+                    .get(key)
+                    .map_or(false, |v| V1::abs_diff_eq(value, v, epsilon.clone()))
+            })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ extern crate num_traits;
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered-float")))]
 extern crate ordered_float;
 
-#[cfg(feature = "vec_impl")]
+#[cfg(any(feature = "vec_impl", feature = "indexmap_impl"))]
 extern crate alloc;
 
 mod abs_diff_eq;

--- a/tests/abs_diff_eq.rs
+++ b/tests/abs_diff_eq.rs
@@ -19,6 +19,8 @@
 #[macro_use]
 extern crate approxim;
 
+mod common;
+
 mod test_f32 {
     use core::f32;
 
@@ -644,5 +646,22 @@ mod test_ordered_float {
         fn test_basic_panic_ne() {
             assert_abs_diff_ne!(OrderedFloat(1.0f64), OrderedFloat(1.0f64));
         }
+    }
+}
+
+#[cfg(feature = "indexmap_impl")]
+mod test_indexmap {
+    use super::common::indexmap::IndexMap;
+
+    #[test]
+    fn test_basic() {
+        assert_abs_diff_eq!(
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)]),
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)])
+        );
+        assert_abs_diff_ne!(
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)]),
+            IndexMap::from_iter([(1, 1.0), (2, 1.0)])
+        );
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,25 @@
+//! This module defines a custom hasher, which can be used in a `#![no_std]` environment.
+//!
+//! The code is taken from [indexmap's `#![no_std]` integration test](https://github.com/indexmap-rs/indexmap/blob/main/test-nostd/src/lib.rs).
+#[cfg(feature = "indexmap_impl")]
+pub mod indexmap {
+    use core::hash::BuildHasherDefault;
+    use core::hash::Hasher;
+
+    #[derive(Default)]
+    pub struct BadHasher(u64);
+
+    impl Hasher for BadHasher {
+        fn finish(&self) -> u64 {
+            self.0
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            for &byte in bytes {
+                self.0 += byte as u64
+            }
+        }
+    }
+
+    pub type IndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<BadHasher>>;
+}

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -19,6 +19,8 @@
 #[macro_use]
 extern crate approxim;
 
+mod common;
+
 mod test_f32 {
     use core::f32;
 
@@ -650,5 +652,22 @@ mod test_ordered_float {
         fn test_basic_panic_ne() {
             assert_relative_ne!(OrderedFloat(1.0f64), OrderedFloat(1.0f64));
         }
+    }
+}
+
+#[cfg(feature = "indexmap_impl")]
+mod test_indexmap {
+    use super::common::indexmap::IndexMap;
+
+    #[test]
+    fn test_basic() {
+        assert_relative_eq!(
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)]),
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)])
+        );
+        assert_relative_ne!(
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)]),
+            IndexMap::from_iter([(1, 1.0), (2, 1.0)])
+        );
     }
 }

--- a/tests/ulps_eq.rs
+++ b/tests/ulps_eq.rs
@@ -19,6 +19,8 @@
 #[macro_use]
 extern crate approxim;
 
+mod common;
+
 mod test_f32 {
     use core::f32;
 
@@ -613,5 +615,22 @@ mod test_ordered_float {
         fn test_basic_panic_ne() {
             assert_ulps_ne!(OrderedFloat(1.0f64), OrderedFloat(1.0f64));
         }
+    }
+}
+
+#[cfg(feature = "indexmap_impl")]
+mod test_indexmap {
+    use super::common::indexmap::IndexMap;
+
+    #[test]
+    fn test_basic() {
+        assert_ulps_eq!(
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)]),
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)])
+        );
+        assert_ulps_ne!(
+            IndexMap::from_iter([(1, 1.0), (2, 2.0)]),
+            IndexMap::from_iter([(1, 1.0), (2, 1.0)])
+        );
     }
 }


### PR DESCRIPTION
As mentioned in PR #2, this PR implements the 3 traits for [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html). See also [#427](https://github.com/indexmap-rs/indexmap/pull/427)

The implementation still works in a `#![no_std]` environment.

Our use case is that we would like to compare collections of 3D coordinates, which are stored in `IndexMap`s. It's relevant to us that we can easily change the threshold of equality, so it would be great if approxim implements its traits on `IndexMap` directly.